### PR TITLE
請求元銀行口座登録更新APIのリクエスト例を修正

### DIFF
--- a/public/bs_bank_transfer/bulk_upsert.md
+++ b/public/bs_bank_transfer/bulk_upsert.md
@@ -107,7 +107,7 @@
             "bank_account_name": "口座名義",
             "bs_department_code": "",
             "journal_cooperation_bank_code": "",
-            "account_title_id": null,
+            "account_title_id": 1120,
             "sub_account_title_code": ""
         }
     ]
@@ -137,7 +137,7 @@ Status: 200 OK
             "bank_account_name": "口座名義",
             "bs_department_code": "",
             "journal_cooperation_bank_code": "",
-            "account_title_id": null,
+            "account_title_id": 1120,
             "sub_account_title_code": ""
         }
     ]


### PR DESCRIPTION
請求元銀行口座登録更新APIの"account_title_id"は必須項目だがリクエスト例ではnullでリクエストしていたので、修正