### PR TITLE
請求書、請求書明細APIのレスポンスの物理名の修正

### DIFF
--- a/dev/bill/search.md
+++ b/dev/bill/search.md
@@ -164,7 +164,7 @@
 | 名前        | 概要             | 型       |
 | ----------- | ---------------- | -------- |
 | update_date | 更新日時         | datetime |
-| count       | 更新日時毎の件数  | int      |
+| update_count | 更新日時毎の件数  | int      |
 
 ## 使用例
 
@@ -282,8 +282,8 @@ Status: 200 OK
     ],
     "count_update_date": [
         {
-            "update_time": "2020/07/01 16:17:18",
-            "count": 1
+            "update_date": "2020/07/01 16:17:18",
+            "update_count": 1
         }
     ]
 }

--- a/dev/bill_detail/search.md
+++ b/dev/bill_detail/search.md
@@ -156,7 +156,7 @@
 | 名前        | 概要             | 型       |
 | ----------- | ---------------- | -------- |
 | update_date | 更新日時         | datetime |
-| count       | 更新日時毎の件数  | int      |
+| update_count | 更新日時毎の件数  | int      |
 
 ## 使用例
 
@@ -270,8 +270,8 @@ Status: 200 OK
     ],
     "count_update_date": [
         {
-            "update_time": "2020/07/21 10:00:00",
-            "count": 4
+            "update_date": "2020/07/21 10:00:00",
+            "update_count": 4
         }
     ]
 }


### PR DESCRIPTION
題名の通り
count_update_dateオブジェクト内部の"count"のカラム名が実装と異なっていたので修正
count -> update_count
