### PR TITLE
請求元口座APIリクエスト例のリファクタ

### DIFF
--- a/public/bs_bank_transfer/bulk_upsert.md
+++ b/public/bs_bank_transfer/bulk_upsert.md
@@ -94,7 +94,7 @@
 {
     "user_id": "sample@robotpayment.co.jp",
     "access_key": "xxxxxxxxxxxxxxxx",
-    " bs_bank_transfer ": [
+    "bs_bank_transfer": [
         {
             "code": "code",
             "title": "銀行口座名",


### PR DESCRIPTION
請求元口座APIリクエスト例に、
不要な空白があったので削除