### PR TITLE
jekyllのローカル用コンテナにパッケージ追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   app:
     image: jekyll/jekyll:pages
-    command: jekyll serve --force_polling
+    command: bash -c "gem install webrick && jekyll serve --force_polling"
     volumes:
       - $PWD:/srv/jekyll
     ports:


### PR DESCRIPTION
ruby3にあがったのでその対応