### PR TITLE
bill_detail/seach APIのレスポンス例から、「issue_date」「transfer_deadline」を削除

### DIFF
--- a/public/bill_detail/search.md
+++ b/public/bill_detail/search.md
@@ -238,7 +238,6 @@ Status: 200 OK
             "billing_code": "sample",
             "billing_individual_number": 1,
             "billing_individual_code": "individual_code",
-            "transfer_deadline": "2020/06/30",
             "bill_detail_id": 40,
             "demand_number": 6,
             "demand_code": "demand_code",

--- a/public/bill_detail/search.md
+++ b/public/bill_detail/search.md
@@ -238,7 +238,6 @@ Status: 200 OK
             "billing_code": "sample",
             "billing_individual_number": 1,
             "billing_individual_code": "individual_code",
-            "issue_date": "2020/06/01",
             "transfer_deadline": "2020/06/30",
             "bill_detail_id": 40,
             "demand_number": 6,


### PR DESCRIPTION
bill_detail/seach APIのレスポンス例から、実際には返却されていない「issue_date」「transfer_deadline」を削除する。

以下課題要望より
https://cloudpayment-sys.slack.com/archives/CMYBNUMMW/p1686658523367319