### PR TITLE
API実行時のuser_idとaccess_keyの案内を追加

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@
       - `https://demo.billing-robo.jp:10443`
 - Accepted content types: `application/json`
 - Encode: `UTF-8`
+- API実行時のユーザーIDとアクセスキー: 請求管理ロボの[ヘルプサイト](https://keirinomikata.zendesk.com/hc/ja/articles/115000131162-API%E6%8E%A5%E7%B6%9A%E8%A8%AD%E5%AE%9A#:~:text=%E4%BE%8B%EF%BC%89192.0.2.0%EF%BD%9E192.0.2.255-,%E2%96%A0API%E5%AE%9F%E8%A1%8C,-%E2%97%8F%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%0A%E3%80%80%E3%80%80%E3%80%80%E3%80%80user_id)参照
 
 ## API一覧
 


### PR DESCRIPTION
## 概要
API仕様書のメインページに、API実行時のユーザーIDとアクセスキーの案内が記載されたヘルプサイトへのリンクを追加

## 関連チケット、リンク
https://cloudpayment-sys.slack.com/archives/C0444983LD6/p1738284128925249